### PR TITLE
simplify linting script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobx-mui-starter",
-  "version": "0.0.2",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobx-mui-starter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-mobx-mui-starter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/StefanWin/react-mobx-mui-starter"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   },
   "description": "",
   "main": "index.js",
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run lint:fix"
+    }
+  },
   "scripts": {
     "start": "node src/dev.js",
     "build": "parcel build ./src/index.html",
@@ -56,6 +61,7 @@
     "eslint-plugin-react": "^7.20.5",
     "express": "^4.17.1",
     "http-proxy-middleware": "^0.20.0",
+    "husky": "^4.2.5",
     "parcel-bundler": "^1.12.4",
     "rimraf": "^3.0.2"
   }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "start": "node src/dev.js",
     "build": "parcel build ./src/index.html",
-    "lint": "eslint --ext .jsx --ext .js ./src"
+    "lint": "eslint --ext .jsx,.js ./src",
+    "lint:fix": "eslint --ext .jsx,.js --fix ./src"
   },
   "keywords": [],
   "author": {


### PR DESCRIPTION
This will update the `lint` script to shorten the `--ext` section.
Additionally adds a `lint:fix` script to the starter kit.